### PR TITLE
remove horizontal scroll bar from entire body

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -34,6 +34,7 @@ html,
 body {
   font-size: 100%; /* 16px */
   color: var(--main-white);
+  overflow-x: hidden;
   font-family: 'Inter', sans-serif;
   font-feature-settings: 'clig' 0, 'liga' 0;
   background: linear-gradient(


### PR DESCRIPTION
This PR addresses an issue causing horizontal scrolling on the main page by applying the CSS property overflow-x: hidden to the body element.

![image](https://github.com/user-attachments/assets/a795686c-6577-4347-bb12-2be47170555d)
